### PR TITLE
Update Flyctl version in deployment workflow

### DIFF
--- a/.github/workflows/fly-deploy.yaml
+++ b/.github/workflows/fly-deploy.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
         with:
-          version: 0.1.54
+          version: 0.4.45
       - name: Install Task
         uses: arduino/setup-task@v1
         with:


### PR DESCRIPTION
`Error: failed to fetch an image or build from source: error connecting to docker: flyctl version too old, must be at least 0.2.71`